### PR TITLE
fix environment for Binder

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,8 @@
-name: BIRSBio-seqFISH
+name: BIRSBiointegration
 channels:
   - conda-forge
   - defaults
+  - bioconda
 dependencies:
   - umap-learn
   - scikit-learn


### PR DESCRIPTION
The `bioconda` channel was required for scanpy